### PR TITLE
feat(updates) Enable requests for updated certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ deploytest:
 		--template-file dist/test-packaged-template.yaml \
 		--capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
 		--stack-name $(APP_NAME)-$(STAGE)-$(BRANCH) \
-		--parameter-overrides DomainName=$(DOMAIN_NAME) HostedZoneId=$(HOSTED_ZONE_ID) SubjectAlternativeNames=""
+		--parameter-overrides DomainName=$(DOMAIN_NAME) HostedZoneId=$(HOSTED_ZONE_ID) SubjectAlternativeNames=$(SUBJECT_ALTERNATIVE_NAMES)
 .PHONY: deploytest
 
 deployci:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:170889777468:applications/serverless-acm-approver
-        SemanticVersion: 1.1.0
+        SemanticVersion: 1.2.0
       Parameters:
         DomainName: !Ref DomainName
         HostedZoneId: !Ref HostedZoneId

--- a/pkg/approver/approver_test.go
+++ b/pkg/approver/approver_test.go
@@ -42,7 +42,7 @@ func TestApprove(t *testing.T) {
 		&acm.DescribeCertificateOutput{Certificate: &acm.CertificateDetail{
 			CertificateArn: aws.String("ghi789"),
 			DomainValidationOptions: []*acm.DomainValidation{
-				&acm.DomainValidation{
+				{
 					ResourceRecord: &acm.ResourceRecord{Name: aws.String("_a.1.t.co"), Type: aws.String("CNAME"), Value: aws.String("abc")},
 				},
 			}}}, nil)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -103,7 +103,7 @@ func (ds *Dispatcher) CreateAndApproveACMCertificate(ctx context.Context, event 
 		}
 
 		return event.PhysicalResourceID, data, nil
-	case cfn.RequestCreate:
+	case cfn.RequestCreate, cfn.RequestUpdate:
 		certificateARN, err := certApprover.Request(ctx, event.RequestID, params.DomainName, params.SubjectAlternativeNames, params.HostedZoneId)
 		if err != nil {
 			return "", data, err

--- a/sam/app/acm-approver.yml
+++ b/sam/app/acm-approver.yml
@@ -20,7 +20,7 @@ Metadata:
     SpdxLicenseId: Apache-2.0
     Labels: [acm, sam, serverless]
     HomePageUrl: https://github.com/wolfeidau/serverless-acm-approver
-    SemanticVersion: 1.1.1
+    SemanticVersion: 1.2.0
     SourceCodeUrl: https://github.com/wolfeidau/serverless-acm-approver/tree/1.0.0
     LicenseUrl: ../../LICENSE
     ReadmeUrl: ../../README.md
@@ -57,7 +57,7 @@ Resources:
                 - route53:ListHostedZones
                 - route53:ChangeResourceRecordSets
               Resource: "*"
-      Timeout: 300
+      Timeout: 600
 
   ACMCertificate:
     Type: "Custom::ACMCertificate"


### PR DESCRIPTION
This change will now create a NEW ACM certificate for updates, and ensure all the SANs are verified correctly.

Also increase the timeout as this is required if you have a few SANs.